### PR TITLE
Upgrade dependencies for Symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 
     "require": {
         "php":                                  ">=5.4",
-        "symfony/console":                      "~2.4",
+        "symfony/console":                      "2.4 - 3",
         "phpdocumentor/reflection-docblock":    "~2.0",
         "egeloen/http-adapter":                 "~0.8",
-        "symfony/event-dispatcher":             "~2.7",
+        "symfony/event-dispatcher":             "2.7 - 3",
         "mattketmo/camel":                      "~1.1",
-        "rybakit/arguments-resolver":           "1.0.x-dev@dev",
+        "rybakit/arguments-resolver":           "~0.5.0",
         "ramsey/array_column":                  "~1.1"
     },
     "require-dev": {

--- a/spec/Console/CommandFactorySpec.php
+++ b/spec/Console/CommandFactorySpec.php
@@ -84,7 +84,7 @@ class CommandFactorySpec extends ObjectBehavior
         $result['services:ping']->getName()->shouldBe('services:ping');
         $result['services:ping']->run(new ArrayInput([]), $output);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 pong
 
 EOS
@@ -136,7 +136,7 @@ EOS
             'onlyContainCommandInstances' => function ($subject) {
                 foreach ($subject as $command) {
                     if (!$command instanceof Command) {
-                        throw new FailureException('"' . get_class($command) . '" is not a subtype of Symfony\Component\Console\Command\Command');
+                        throw new FailureException('"'.get_class($command).'" is not a subtype of Symfony\Component\Console\Command\Command');
                     }
                 }
 

--- a/spec/Output/GithubSpec.php
+++ b/spec/Output/GithubSpec.php
@@ -18,7 +18,7 @@ class GithubSpec extends ObjectBehavior
 
         $this->sync($output, ['status' => 'done']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS
@@ -31,7 +31,7 @@ EOS
 
         $this->delete($output, ['success' => 'failure']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 failure
 
 EOS
@@ -44,7 +44,7 @@ EOS
 
         $this->hook($output, ['success' => 'failure']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 failure
 
 EOS
@@ -56,7 +56,7 @@ EOS
         $output = new BufferedOutput();
         $this->repos($output, ['repos' => [['fullname' => 'digitalkaoz/versioneye-php', 'language' => 'php', 'description' => 'wrapper around versioneye api', 'owner_login' => 'digitalkaoz', 'fork' => false, 'foo' => 'bazz']]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+-------------------------------+-------------+------+
 | Name                       | Language | Description                   | Owner       | Fork |
 +----------------------------+----------+-------------------------------+-------------+------+
@@ -81,7 +81,7 @@ EOS
             'git_url'     => 'git@github.com:digitalkaoz/versioneye-php.git',
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Name             : digitalkaoz/versioneye-php
 Homepage         : http://digitalkaoz.github.io/versioneye-php
 Language         : php
@@ -109,7 +109,7 @@ EOS
             'git_url'     => 'git@github.com:digitalkaoz/versioneye-php.git',
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Name             : digitalkaoz/versioneye-php
 Homepage         : http://digitalkaoz.github.io/versioneye-php
 Language         : php

--- a/spec/Output/MeSpec.php
+++ b/spec/Output/MeSpec.php
@@ -23,7 +23,7 @@ class MeSpec extends ObjectBehavior
             'notifications' => ['new' => 10, 'total' => 100],
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Fullname           : Robert Schönthal
 Username           : digitalkaoz
 Email              : robert.schoenthal@gmail.com
@@ -39,7 +39,7 @@ EOS
         $output = new BufferedOutput();
         $this->favorites($output, ['favorites' => [['name' => 'digitalkaoz/versioneye-php', 'language' => 'php', 'version' => '1.0.0', 'prod_type' => 'composer']]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -55,7 +55,7 @@ EOS
         $output = new BufferedOutput();
         $this->notifications($output, ['notifications' => [['name' => 'digitalkaoz/versioneye-php', 'language' => 'php', 'version' => '1.0.0', 'prod_type' => 'composer']]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -77,7 +77,7 @@ EOS
             ],
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+------------+---------+
 | Name                       | Language | Version | Type     | Date       | Comment |
 +----------------------------+----------+---------+----------+------------+---------+

--- a/spec/Output/ProductsSpec.php
+++ b/spec/Output/ProductsSpec.php
@@ -24,7 +24,7 @@ class ProductsSpec extends ObjectBehavior
             ],
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -49,7 +49,7 @@ EOS
                 ],
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Name          : digitalkaoz/versioneye-php
 Language      : php
 Key           : 2
@@ -78,7 +78,7 @@ EOS
             ],
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -108,7 +108,7 @@ EOS
             ],
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Name             : digitalkaoz/versioneye-php
 Description      : a php wrapper around the versioneye api
 Source           : http://lolcat.com
@@ -135,7 +135,7 @@ EOS
 
         $this->followStatus($output, ['follows' => false]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 NO
 
 EOS
@@ -148,7 +148,7 @@ EOS
 
         $this->follow($output, ['follows' => true]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS
@@ -161,7 +161,7 @@ EOS
 
         $this->unfollow($output, ['follows' => false]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS

--- a/spec/Output/ProjectsSpec.php
+++ b/spec/Output/ProjectsSpec.php
@@ -30,7 +30,7 @@ class ProjectsSpec extends ObjectBehavior
             ],
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +------------------------------+----------------------------+----------+--------+--------------+----------+------------+--------------+------------------+
 | Key                          | Name                       | Type     | Public | Dependencies | Outdated | Updated At | Bad Licenses | Unknown Licenses |
 +------------------------------+----------------------------+----------+--------+--------------+----------+------------+--------------+------------------+
@@ -53,7 +53,7 @@ EOS
             ]],
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +---------+----------------------------+
 | license | name                       |
 +---------+----------------------------+
@@ -86,7 +86,7 @@ EOS
 
         $this->delete($output, ['success' => true, 'message' => 'foo']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 foo
 
 EOS
@@ -99,7 +99,7 @@ EOS
 
         $this->merge($output, ['success' => true]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS
@@ -112,7 +112,7 @@ EOS
 
         $this->mergeGa($output, ['success' => true]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS
@@ -125,7 +125,7 @@ EOS
 
         $this->unmerge($output, ['success' => false]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 FAIL
 
 EOS
@@ -156,7 +156,7 @@ EOS
             ]],
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Name                  : digitalkaoz/versioneye-php
 Key                   : digitalkaoz_versioneye-php_1
 Type                  : composer

--- a/spec/Output/ServicesSpec.php
+++ b/spec/Output/ServicesSpec.php
@@ -18,7 +18,7 @@ class ServicesSpec extends ObjectBehavior
 
         $this->ping($output, ['success' => true, 'message' => 'pong']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 pong
 
 EOS

--- a/spec/Output/SessionsSpec.php
+++ b/spec/Output/SessionsSpec.php
@@ -21,7 +21,7 @@ class SessionsSpec extends ObjectBehavior
             'email'    => 'robert.schoenthal@gmail.com',
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Fullname       : Robert Schönthal
 API Token      : 1337
 
@@ -35,7 +35,7 @@ EOS
 
         $this->open($output, 'true');
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS
@@ -48,7 +48,7 @@ EOS
 
         $this->close($output, ['message' => 'Session is closed now.']);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 OK
 
 EOS

--- a/spec/Output/UsersSpec.php
+++ b/spec/Output/UsersSpec.php
@@ -21,7 +21,7 @@ class UsersSpec extends ObjectBehavior
             'email'    => 'robert.schoenthal@gmail.com',
         ]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 Fullname      : Robert Schönthal
 Username      : digitalkaoz
 
@@ -34,7 +34,7 @@ EOS
         $output = new BufferedOutput();
         $this->favorites($output, ['favorites' => [['name' => 'digitalkaoz/versioneye-php', 'language' => 'php', 'version' => '1.0.0', 'prod_type' => 'composer']]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -50,7 +50,7 @@ EOS
         $output = new BufferedOutput();
         $this->notifications($output, ['notifications' => [['name' => 'digitalkaoz/versioneye-php', 'language' => 'php', 'version' => '1.0.0', 'prod_type' => 'composer']]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+
 | Name                       | Language | Version | Type     |
 +----------------------------+----------+---------+----------+
@@ -72,7 +72,7 @@ EOS
             ],
         ]]);
 
-        expect($output->fetch())->toBe(<<<EOS
+        expect($output->fetch())->toBe(<<<'EOS'
 +----------------------------+----------+---------+----------+------------+---------+
 | Name                       | Language | Version | Type     | Date       | Comment |
 +----------------------------+----------+---------+----------+------------+---------+

--- a/src/Api/BaseApi.php
+++ b/src/Api/BaseApi.php
@@ -25,7 +25,7 @@ abstract class BaseApi
     public function __construct(HttpClient $client, $token = null)
     {
         $this->client = $client;
-        $this->token  = $token;
+        $this->token = $token;
     }
 
     /**
@@ -78,7 +78,7 @@ abstract class BaseApi
     private function sanitizeQuery($query)
     {
         $parts = parse_url($query);
-        $path  = $parts['path'];
+        $path = $parts['path'];
 
         if (!isset($parts['query'])) {
             return $query;
@@ -101,7 +101,7 @@ abstract class BaseApi
             }
         }
 
-        return $path . '?' . http_build_query($final);
+        return $path.'?'.http_build_query($final);
     }
 
     /**

--- a/src/Api/Github.php
+++ b/src/Api/Github.php
@@ -48,7 +48,7 @@ class Github extends BaseApi implements Api
      */
     public function show($repository)
     {
-        return $this->request('github/' . $this->transform($repository));
+        return $this->request('github/'.$this->transform($repository));
     }
 
     /**

--- a/src/Api/Projects.php
+++ b/src/Api/Projects.php
@@ -30,7 +30,7 @@ class Projects extends BaseApi implements Api
      */
     public function show($project)
     {
-        return $this->request('projects/' . $project);
+        return $this->request('projects/'.$project);
     }
 
     /**
@@ -42,7 +42,7 @@ class Projects extends BaseApi implements Api
      */
     public function delete($project)
     {
-        return $this->request('projects/' . $project, 'DELETE');
+        return $this->request('projects/'.$project, 'DELETE');
     }
 
     /**
@@ -67,7 +67,7 @@ class Projects extends BaseApi implements Api
      */
     public function update($project, $file)
     {
-        return $this->request('projects/' . $project, 'POST', ['project_file' => $file]);
+        return $this->request('projects/'.$project, 'POST', ['project_file' => $file]);
     }
 
     /**

--- a/src/Api/Users.php
+++ b/src/Api/Users.php
@@ -20,7 +20,7 @@ class Users extends BaseApi implements Api
      */
     public function show($username)
     {
-        return $this->request('users/' . $username);
+        return $this->request('users/'.$username);
     }
 
     /**

--- a/src/Authentication/RubyConfigFileToken.php
+++ b/src/Authentication/RubyConfigFileToken.php
@@ -17,7 +17,7 @@ class RubyConfigFileToken implements Token
     public function __construct($file = null)
     {
         if (null === $file) {
-            $file = $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.veye.rc';
+            $file = $_SERVER['HOME'].DIRECTORY_SEPARATOR.'.veye.rc';
         }
 
         $this->file = $file;

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,12 +46,12 @@ class Client
      */
     public function api($name)
     {
-        $class = 'Rs\\VersionEye\\Api\\' . ucfirst($name);
+        $class = 'Rs\\VersionEye\\Api\\'.ucfirst($name);
 
         if (class_exists($class)) {
             return new $class($this->client, $this->token);
         } else {
-            throw new \InvalidArgumentException('unknown api "' . $name . '" requested');
+            throw new \InvalidArgumentException('unknown api "'.$name.'" requested');
         }
     }
 

--- a/src/Console/CommandFactory.php
+++ b/src/Console/CommandFactory.php
@@ -35,7 +35,7 @@ class CommandFactory
     public function __construct(Token $token, CaseTransformerInterface $transformer)
     {
         $this->transformer = $transformer;
-        $this->token       = $token;
+        $this->token = $token;
     }
 
     /**
@@ -47,8 +47,8 @@ class CommandFactory
      */
     public function generateCommands(array $classes = [])
     {
-        $classes  = $this->readApis($classes);
-        $token    = $this->token->read();
+        $classes = $this->readApis($classes);
+        $token = $this->token->read();
         $commands = [];
 
         foreach ($classes as $class) {
@@ -56,7 +56,7 @@ class CommandFactory
 
             foreach ($api->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
                 if (0 !== strpos($method->getName(), '__')) { //skip magics
-                    $command                       = $this->generateCommand($api->getShortName(), $method, $token);
+                    $command = $this->generateCommand($api->getShortName(), $method, $token);
                     $commands[$command->getName()] = $command;
                 }
             }
@@ -78,7 +78,7 @@ class CommandFactory
     {
         $methodName = $this->transformer->transform($method->getName());
 
-        $command  = new Command(strtolower($name . ':' . $methodName));
+        $command = new Command(strtolower($name.':'.$methodName));
         $docBlock = new DocBlock($method->getDocComment());
 
         $command->setDefinition($this->buildDefinition($method, $token));
@@ -133,9 +133,9 @@ class CommandFactory
                 $client->authorize($input->getOption('token'));
             }
 
-            $methodName  = $method->getName();
-            $api         = $client->api(strtolower($name));
-            $args        = (new NamedArgumentsResolver($method))->resolve(array_merge($input->getOptions(), $input->getArguments()));
+            $methodName = $method->getName();
+            $api = $client->api(strtolower($name));
+            $args = (new NamedArgumentsResolver($method))->resolve(array_merge($input->getOptions(), $input->getArguments()));
             $outputClass = $this->generateOutputClassFromApiClass($api);
 
             $response = call_user_func_array([$api, $methodName], $args);
@@ -181,9 +181,9 @@ class CommandFactory
     private function generateOutputClassFromApiClass(Api $api)
     {
         $classParts = explode('\\', get_class($api));
-        $apiName    = array_pop($classParts);
+        $apiName = array_pop($classParts);
         array_pop($classParts);
 
-        return implode('\\', $classParts) . '\\Output\\' . $apiName;
+        return implode('\\', $classParts).'\\Output\\'.$apiName;
     }
 }

--- a/src/Http/IvoryHttpAdapterClient.php
+++ b/src/Http/IvoryHttpAdapterClient.php
@@ -26,7 +26,7 @@ class IvoryHttpAdapterClient implements HttpClient
     public function __construct(HttpAdapterInterface $adapter, $url)
     {
         $this->adapter = $adapter;
-        $this->url     = $url;
+        $this->url = $url;
     }
 
     /**
@@ -37,7 +37,7 @@ class IvoryHttpAdapterClient implements HttpClient
         list($params, $files) = $this->fixParams($params);
 
         try {
-            $response = $this->adapter->send($this->url . $url, $method, [], $params, $files);
+            $response = $this->adapter->send($this->url.$url, $method, [], $params, $files);
 
             return json_decode($response->getBody(), true);
         } catch (HttpAdapterException $e) {
@@ -55,7 +55,7 @@ class IvoryHttpAdapterClient implements HttpClient
     private function fixParams(array $params)
     {
         $parameters = [];
-        $files      = [];
+        $files = [];
 
         foreach ($params as $name => $value) {
             if (is_readable($value)) { //file
@@ -77,9 +77,9 @@ class IvoryHttpAdapterClient implements HttpClient
      */
     private function buildRequestError(HttpAdapterException $e)
     {
-        $data    = $e->getResponse() ? json_decode($e->getResponse()->getBody(), true) : ['error' => $e->getMessage()];
+        $data = $e->getResponse() ? json_decode($e->getResponse()->getBody(), true) : ['error' => $e->getMessage()];
         $message = isset($data['error']) ? $data['error'] : 'Server Error';
-        $status  = $e->getResponse() ? $e->getResponse()->getStatusCode() : 500;
+        $status = $e->getResponse() ? $e->getResponse()->getStatusCode() : 500;
 
         return new CommunicationException(sprintf('%s : %s', $status, $message));
     }

--- a/src/Http/Pager.php
+++ b/src/Http/Pager.php
@@ -9,10 +9,10 @@ namespace Rs\VersionEye\Http;
  */
 class Pager implements \Iterator
 {
-    private $offset  = 0;
+    private $offset = 0;
     private $current = 1;
-    private $max     = 0;
-    private $result  = [];
+    private $max = 0;
+    private $result = [];
 
     /**
      * @var HttpClient
@@ -34,13 +34,13 @@ class Pager implements \Iterator
     public function __construct(array $result, $key, HttpClient $client, $method, $url, array $params = [])
     {
         $this->current = $result['paging']['current_page'];
-        $this->max     = $result['paging']['total_entries'];
-        $this->result  = $result[$key];
+        $this->max = $result['paging']['total_entries'];
+        $this->result = $result[$key];
 
-        $this->key    = $key;
+        $this->key = $key;
         $this->client = $client;
         $this->method = $method;
-        $this->url    = $url;
+        $this->url = $url;
         $this->params = $params;
     }
 
@@ -75,7 +75,7 @@ class Pager implements \Iterator
     {
         if (!isset($this->result[$this->offset]) && $this->offset < $this->max) {
             ++$this->current;
-            $url    = preg_replace('/page=[0-9]+/', 'page=' . $this->current, $this->url);
+            $url = preg_replace('/page=[0-9]+/', 'page='.$this->current, $this->url);
             $result = $this->client->request($this->method, $url, $this->params);
 
             $this->result = array_merge($this->result, $result[$this->key]);

--- a/src/Output/BaseOutput.php
+++ b/src/Output/BaseOutput.php
@@ -54,9 +54,9 @@ abstract class BaseOutput
     protected function printBoolean(OutputInterface $output, $success, $fail, $value, $line = true)
     {
         if ($value) {
-            $message = '<info>' . $success . '</info>';
+            $message = '<info>'.$success.'</info>';
         } else {
-            $message = '<error>' . $fail . '</error>';
+            $message = '<error>'.$fail.'</error>';
         }
 
         if (false === $line) {
@@ -78,7 +78,7 @@ abstract class BaseOutput
     protected function printList(OutputInterface $output, array $headings, array $keys, array $data, \Closure $callback = null)
     {
         $width = $this->getColumnWidth($headings);
-        $data  = array_merge(array_flip($keys), array_intersect_key($data, array_flip($keys)));
+        $data = array_merge(array_flip($keys), array_intersect_key($data, array_flip($keys)));
 
         foreach ($headings as $key => $heading) {
             $value = array_values($data)[$key];

--- a/src/Output/Products.php
+++ b/src/Output/Products.php
@@ -47,7 +47,7 @@ class Products extends BaseOutput
             $response,
             function ($heading, $value) {
                 if ('Source' === $heading) {
-                    $value = array_filter($value, function ($link) { return 'Source' === $link['name'];});
+                    $value = array_filter($value, function ($link) { return 'Source' === $link['name']; });
 
                     if (!empty($value)) {
                         return array_pop($value)['link'];

--- a/src/Output/Projects.php
+++ b/src/Output/Projects.php
@@ -50,7 +50,7 @@ class Projects extends BaseOutput
 
         foreach ($response['licenses'] as $license => $projects) {
             foreach ($projects as $project) {
-                $name    = $license === 'unknown' ? '<error>' . $project['name'] . '</error>' : $project['name'];
+                $name = $license === 'unknown' ? '<error>'.$project['name'].'</error>' : $project['name'];
                 $license = $license === 'unknown' ? '<error>unknown</error>' : $license;
 
                 $table->addRow([$license, $name]);


### PR DESCRIPTION
Include Symfony components in version 3 and fix versioning scheme for rybakit/arguments-resolver.

Hi Robert, I was trying to install [mattsches/VersionEyeBundle](https://github.com/mattsches/VersionEyeBundle) in a Symfony3 project, but it failed. This is an attempt to resolve the dependency problems.